### PR TITLE
Modifications to establish compatibility with Virtual hardware

### DIFF
--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -18,7 +18,16 @@
  */
 
 #include "Kaleidoscope.h"
+
+#ifdef ARDUINO_VIRTUAL
+#include "VirtualHID/VirtualHID.h"
+#ifdef KALEIDOSCOPE_HIDADAPTOR_ENABLE_KEYBOARD_BOOT_PROTOCOL
+#   undef KALEIDOSCOPE_HIDADAPTOR_ENABLE_KEYBOARD_BOOT_PROTOCOL
+#   define KALEIDOSCOPE_HIDADAPTOR_ENABLE_KEYBOARD_BOOT_PROTOCOL 0
+#endif
+#else
 #include "KeyboardioHID.h"
+#endif
 
 #if KALEIDOSCOPE_HIDADAPTOR_ENABLE_KEYBOARD_BOOT_PROTOCOL
 #include "BootKeyboard/BootKeyboard.h"
@@ -32,19 +41,19 @@
 /** Fall back to BootKeyboard, if the HID protocol is Boot.
  * Requires a block of code to follow.
  */
-#define WITH_BOOTKEYBOARD_PROTOCOL if (BootKeyboard.getProtocol() == HID_BOOT_PROTOCOL)
+#define WITH_BOOTKEYBOARD_PROTOCOL(...) if (BootKeyboard.getProtocol() == HID_BOOT_PROTOCOL) { __VA_ARGS__ }
 /** Do something with BootKeyboard, if it is enabled.
  * Requires a block of code to follow.
  */
-#define WITH_BOOTKEYBOARD
+#define WITH_BOOTKEYBOARD(...) __VA_ARGS__
 
 #else /* KALEIDOSCOPE_HIDADAPTOR_ENABLE_KEYBOARD_BOOT_PROTOCOL unset */
 
 /* Wrap both macros in "if (0)", so that the compiler removes any code that
  * follows.
  */
-#define WITH_BOOTKEYBOARD_PROTOCOL if (0)
-#define WITH_BOOTKEYBOARD if (0)
+#define WITH_BOOTKEYBOARD_PROTOCOL(...)
+#define WITH_BOOTKEYBOARD(...)
 
 #endif
 
@@ -53,16 +62,16 @@ namespace hid {
 
 void initializeKeyboard() {
   Keyboard.begin();
-  WITH_BOOTKEYBOARD {
+  WITH_BOOTKEYBOARD(
     BootKeyboard.begin();
-  }
+  )
 }
 
 void pressRawKey(Key mappedKey) {
-  WITH_BOOTKEYBOARD_PROTOCOL {
+  WITH_BOOTKEYBOARD_PROTOCOL(
     BootKeyboard.press(mappedKey.keyCode);
     return;
-  }
+  )
 
   Keyboard.press(mappedKey.keyCode);
 }
@@ -88,18 +97,18 @@ void pressKey(Key mappedKey) {
 }
 
 void releaseRawKey(Key mappedKey) {
-  WITH_BOOTKEYBOARD_PROTOCOL {
+  WITH_BOOTKEYBOARD_PROTOCOL(
     BootKeyboard.release(mappedKey.keyCode);
     return;
-  }
+  )
 
   Keyboard.release(mappedKey.keyCode);
 }
 
 void releaseAllKeys() {
-  WITH_BOOTKEYBOARD {
+  WITH_BOOTKEYBOARD(
     BootKeyboard.releaseAll();
-  }
+  )
 
   Keyboard.releaseAll();
   ConsumerControl.releaseAll();
@@ -125,35 +134,35 @@ void releaseKey(Key mappedKey) {
 }
 
 boolean isModifierKeyActive(Key mappedKey) {
-  WITH_BOOTKEYBOARD_PROTOCOL {
+  WITH_BOOTKEYBOARD_PROTOCOL(
     return BootKeyboard.isModifierActive(mappedKey.keyCode);
-  }
+  )
 
   return Keyboard.isModifierActive(mappedKey.keyCode);
 }
 
 boolean wasModifierKeyActive(Key mappedKey) {
-  WITH_BOOTKEYBOARD_PROTOCOL {
+  WITH_BOOTKEYBOARD_PROTOCOL(
     return BootKeyboard.wasModifierActive(mappedKey.keyCode);
-  }
+  )
 
   return Keyboard.wasModifierActive(mappedKey.keyCode);
 }
 
 uint8_t getKeyboardLEDs() {
-  WITH_BOOTKEYBOARD_PROTOCOL {
+  WITH_BOOTKEYBOARD_PROTOCOL(
     return BootKeyboard.getLeds();
-  }
+  )
 
   return Keyboard.getLEDs();
 }
 
 
 void sendKeyboardReport() {
-  WITH_BOOTKEYBOARD_PROTOCOL {
+  WITH_BOOTKEYBOARD_PROTOCOL(
     BootKeyboard.sendReport();
     return;
-  }
+  )
 
   Keyboard.sendReport();
   ConsumerControl.sendReport();


### PR DESCRIPTION
After recent changes in the HID design, virtual builds ceased working.

The reason is that this plugin includes `KeyboardioHID.h` instead of checking for the build type and conditionally including `Virtual/VirtualHID.h` from Kaleidoscope-Hardware-Virtual.

This plugin adds conditional includes as well as real pre-processor based conditional compilation of boot protocol stuff. The original implementation used `if(0) {...}` clauses which are optimized away by the compiler but compiled anyway, which leads to compiler errors as `BootKeyboard` is unknown to the virtual hardware.

@cdisselkoen: Could you please double check this if it is actually compatible with KHV as a standalone build. Also I am not sure if the `BootKeyboard` could/should be added to the virtual hardware?

We still don't have regression testing with KHV which would really help to maintain compatibility.