### PR TITLE
A fix for rollover from a mod-flagged key

### DIFF
--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -127,8 +127,8 @@ void initializeKeyboard() {
 // without it, that modifier flag won't affect the new keypress.
 void setLastKeyPress(Key mappedKey) {
   mod_flags_allowed = mappedKey.flags;
-  current_mod_flags = mappedKey.flags;
   toggled_on_keycode = mappedKey.keyCode;
+  pressKey(mappedKey);
 }
 
 void pressRawKey(Key mappedKey) {

--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -127,6 +127,7 @@ void releaseAllKeys() {
     BootKeyboard.releaseAll();
   }
 
+  mod_flags = 0;
   Keyboard.releaseAll();
   ConsumerControl.releaseAll();
 }

--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -124,7 +124,17 @@ void initializeKeyboard() {
 // key that just toggled on, so when we roll over from a key with a modifier flag to one
 // without it, that modifier flag won't affect the new keypress.
 void pressToggledOnKey(Key mappedKey) {
-  mod_flags_allowed = mappedKey.flags;
+  // In the event that two keys toggle on in the same scan cycle, we would ideally send an
+  // extra report so that each key gets processed fully, but this is problematic. If we
+  // simply allow the second new keypress's mod flags to take precedence, we can sometimes
+  // get a flag removed before the report is sent, so we simply allow flags from both
+  // keys. This is not ideal, but it is at worst the same as the previous behaviour, where
+  // rollover from a mod-flagged key would alway affect the second keypress.
+  if (newly_toggled_on_keycode != 0) {
+    mod_flags_allowed |= mappedKey.flags;
+  } else {
+    mod_flags_allowed = mappedKey.flags;
+  }
   newly_toggled_on_keycode = mappedKey.keyCode;
   pressKey(mappedKey);
 }

--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -76,7 +76,6 @@ static byte mod_flags_allowed{0};
 static byte newly_toggled_on_keycode{0};
 
 // This returns true if the key is a keyboard key, and its keycode is a modifier.
-inline
 bool isPureModifier(Key mappedKey) {
   // If it's not a keyboard key, return false
   if (mappedKey.flags & (SYNTHETIC | RESERVED))
@@ -87,13 +86,11 @@ bool isPureModifier(Key mappedKey) {
 
 // This function adds modifier flags to the bitfield for current modifier flags that will
 // be added to the report after all keys are scanned.
-inline
 void requestModFlags(byte flags) {
   requested_mod_flags |= flags;
 }
 
 // This function actually adds the modifier flags to the upcoming report.
-inline
 void pressModFlags(byte flags) {
   if (flags & SHIFT_HELD) {
     pressRawKey(Key_LeftShift);

--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -80,11 +80,8 @@ bool isPureModifier(Key mappedKey) {
   // If it's not a keyboard key, return false
   if (mappedKey.flags & (SYNTHETIC | RESERVED))
     return false;
-  // An efficient way to check if the keycode is for a modifier. Key_LeftControl has the
-  // modifier keycode with the lowest value, and the others are sequential, and we use an
-  // unsigned integer so after subtraction, the comparison is simple.
-  byte offset_keycode = mappedKey.keyCode - Key_LeftControl.keyCode;
-  return (offset_keycode < 8);
+  return (mappedKey.keyCode >= HID_KEYBOARD_FIRST_MODIFIER &&
+          mappedKey.keyCode <= HID_KEYBOARD_LAST_MODIFIER);
 }
 
 // This function adds modifier flags to the bitfield for current modifier flags that will

--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -54,21 +54,45 @@ namespace hid {
 // Anonymous namespace for internal variables and helper functions
 namespace {
 
-static byte mod_flags{0};
+// The functions in this namespace are primarily to solve the problem of rollover from a
+// key with a modifier flag (e.g. `LSHIFT(Key_T)`) to one without (e.g. `Key_H`), which
+// used to result in the mod flag being applied to keys other than the one with the
+// flag. By using `mod_flags_allowed`, we can prohibit any modifier flags that aren't in
+// the key most recently pressed, fixing the rollover problem, and getting the intended
+// `The` instead of `THe`. This was particularly noticeable to people who were using a
+// separate layer for `shift`, and a OneShot layer key to activate it, causing what looked
+// like a OneShot bug.
+
+// A bitfield of the current modifier flags from keys processed so far in the current
+// keyswitch scan:
+static byte current_mod_flags{0};
+
+// The current set of modifier flags that will be allowed to be added to the upcoming
+// keyboard HID report. This should be set by the latest key pressed:
 static byte mod_flags_allowed{0};
+
+// The keycode of the last key to toggle on. This get
 static byte toggled_on_keycode{0};
 
+// This returns true if the key is a keyboard key, and its keycode is a modifier.
 bool isPureModifier(Key mappedKey) {
+  // If it's not a keyboard key, return false
   if (mappedKey.flags & (SYNTHETIC | RESERVED))
     return false;
+  // An efficient way to check if the keycode is for a modifier. Key_LeftControl has the
+  // modifier keycode with the lowest value, and the others are sequential, and we use an
+  // unsigned integer so after subtraction, the comparison is simple.
   byte offset_keycode = mappedKey.keyCode - Key_LeftControl.keyCode;
   return (offset_keycode < 8);
 }
 
+// This function adds modifier flags to the bitfield for current modifier flags that will
+// be added to the report after all keys are scanned.
 void addModFlags(byte flags) {
-  mod_flags |= flags;
+  current_mod_flags |= flags;
 }
 
+// This function actually adds the modifier flags to the upcoming report.
 void pressModFlags(byte flags) {
   if (flags & SHIFT_HELD) {
     pressRawKey(Key_LeftShift);
@@ -89,6 +113,7 @@ void pressModFlags(byte flags) {
 
 } // anonymous namespace
 
+
 void initializeKeyboard() {
   Keyboard.begin();
   WITH_BOOTKEYBOARD {
@@ -96,9 +121,13 @@ void initializeKeyboard() {
   }
 }
 
+// Called from handleKeyswitchEventDefault when a key toggles on. This sets the mask of
+// modifier flags that are allowed to be added to the upcoming report to the ones in the
+// key that just toggled on, so when we roll over from a key with a modifier flag to one
+// without it, that modifier flag won't affect the new keypress.
 void setLastKeyPress(Key mappedKey) {
   mod_flags_allowed = mappedKey.flags;
-  mod_flags = mappedKey.flags;
+  current_mod_flags = mappedKey.flags;
   toggled_on_keycode = mappedKey.keyCode;
 }
 
@@ -112,6 +141,12 @@ void pressRawKey(Key mappedKey) {
 }
 
 void pressKey(Key mappedKey) {
+  // If the key we're processing is a "pure" modifier key, its modifier flags are added
+  // directly to the report along with the modifier from its keycode byte. We assume that
+  // the flagged modifiers are intended to also modify other keys pressed while this key
+  // is held, so they are allowed unconditionally. If it's not a "pure" modifier key, we
+  // add them to current_mod_flags, and only allow them to affect the report if the latest
+  // keypress includes those modifiers.
   if (isPureModifier(mappedKey)) {
     pressModFlags(mappedKey.flags);
   } else {
@@ -135,7 +170,7 @@ void releaseAllKeys() {
     BootKeyboard.releaseAll();
   }
 
-  mod_flags = 0;
+  current_mod_flags = 0;
   toggled_on_keycode = 0;
   Keyboard.releaseAll();
   ConsumerControl.releaseAll();
@@ -187,15 +222,25 @@ uint8_t getKeyboardLEDs() {
 
 void sendKeyboardReport() {
 
-  pressModFlags(mod_flags & mod_flags_allowed);
+  // Before sending the report, we add any modifier flags that are currently allowed,
+  // based on the latest keypress:
+  pressModFlags(current_mod_flags & mod_flags_allowed);
 
+  // If a key has just toggled on, we assume that the user expects that key's keycode to
+  // be sent as a new event immediately, so we make sure that a report is sent without
+  // that keycode. In the usual case, this won't result in any difference from the
+  // previous report, so no extra report will be sent. If there is a difference in the
+  // modifiers byte, an extra report would be sent later, regardless. The only time we
+  // should genuinely see an extra report from this is if we need one because a user
+  // rolled over from `X` to `x`, or if they've got a keymap with two `e` keys because
+  // they find it problematic to double-tap the same key frequently.
   WITH_BOOTKEYBOARD_PROTOCOL {
     if (toggled_on_keycode) {
       BootKeyboard.release(toggled_on_keycode);
       BootKeyboard.sendReport();
       BootKeyboard.press(toggled_on_keycode);
+      toggled_on_keycode = 0;
     }
-    toggled_on_keycode = 0;
 
     BootKeyboard.sendReport();
     return;
@@ -205,8 +250,8 @@ void sendKeyboardReport() {
     Keyboard.release(toggled_on_keycode);
     Keyboard.sendReport();
     Keyboard.press(toggled_on_keycode);
+    toggled_on_keycode = 0;
   }
-  toggled_on_keycode = 0;
 
   Keyboard.sendReport();
   ConsumerControl.sendReport();

--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -125,7 +125,7 @@ void initializeKeyboard() {
 // modifier flags that are allowed to be added to the upcoming report to the ones in the
 // key that just toggled on, so when we roll over from a key with a modifier flag to one
 // without it, that modifier flag won't affect the new keypress.
-void setLastKeyPress(Key mappedKey) {
+void pressToggledOnKey(Key mappedKey) {
   mod_flags_allowed = mappedKey.flags;
   toggled_on_keycode = mappedKey.keyCode;
   pressKey(mappedKey);


### PR DESCRIPTION
When rollover occurs from a `Key` with a modifier flag to one without, the modifier flag should not be applied to the new keypress. This change makes that possible by adding a mask for mod flags, and only allowing the flags from the latest keypress to be added to the report, with the exception of "pure" modifiers (anything with a modifier `keyCode` value still gets its mod flags added, regardless).

This is not well-commented or thoroughly tested yet, but I don't have sufficient time right now, and I want to get this out to @noseglasses, who was interested in getting a solution to the rollover bug.