### PR TITLE
Revert "Add getKeyswitchStateAtPosition wrappers"

### DIFF
--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -140,14 +140,6 @@ boolean wasModifierKeyActive(Key mappedKey) {
   return Keyboard.wasModifierActive(mappedKey.keyCode);
 }
 
-uint8_t getKeyswitchStateAtPosition(byte row, byte col) {
-  return KeyboardHardware.getKeyswitchStateAtPosition(row, col);
-}
-
-uint8_t getKeyswitchStateAtPosition(uint8_t keyIndex) {
-  return KeyboardHardware.getKeyswitchStateAtPosition(keyIndex);
-}
-
 uint8_t getKeyboardLEDs() {
   WITH_BOOTKEYBOARD_PROTOCOL {
     return BootKeyboard.getLeds();


### PR DESCRIPTION
Reverts keyboardio/Kaleidoscope-HIDAdaptor-KeyboardioHID#6, because these are sufficiently low-level that using `KeyboardHardware` for them is OK. They aren't HID stuff, either.