### PR TITLE
Only set "last keycode toggled on" to a non-modifier keycode.

### DIFF
--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -188,7 +188,9 @@ void pressKey(Key pressed_key, boolean toggled_on) {
     // willing to attach to USB HID keyboard reports
     modifier_flag_mask |= pressed_key.flags;
 
-    last_keycode_toggled_on = pressed_key.keyCode;
+    if (!isModifierKey(pressed_key)) {
+      last_keycode_toggled_on = pressed_key.keyCode;
+    }
   }
 
 


### PR DESCRIPTION
Without this change plugins like oneshot that toggle shift on
programatically end up flapping wildly, toggling the key in question off
over and over, but not toggling it on when necessary