### PR TITLE
Add functions to determine if modifiers are/were active

### DIFF
--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -308,6 +308,22 @@ boolean wasModifierKeyActive(Key modifier_key) {
   return Keyboard.wasModifierActive(modifier_key.keyCode);
 }
 
+boolean isAnyModifierKeyActive() {
+  WITH_BOOTKEYBOARD_PROTOCOL {
+    return BootKeyboard.isAnyModifierActive();
+  }
+
+  return Keyboard.isAnyModifierActive();
+}
+
+boolean wasAnyModifierKeyActive() {
+  WITH_BOOTKEYBOARD_PROTOCOL {
+    return BootKeyboard.wasAnyModifierActive();
+  }
+
+  return Keyboard.wasAnyModifierActive();
+}
+
 uint8_t getKeyboardLEDs() {
   WITH_BOOTKEYBOARD_PROTOCOL {
     return BootKeyboard.getLeds();


### PR DESCRIPTION
Part of the resolution for [532 on Kaleidoscope](https://github.com/keyboardio/Kaleidoscope/issues/532).